### PR TITLE
all: bump to Go-1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.17
       - name: Get dependencies
         run: go get -v -t -d ./...
       - name: Run tests and generate coverage report

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@
 
 module github.com/nlpodyssey/gopickle
 
-go 1.15
+go 1.17
 
 require golang.org/x/text v0.14.0


### PR DESCRIPTION
`x/text@v0.14.0` uses syntax (the `//go:build tag`) that depends on Go-1.17.