### PR TITLE
pickle: handle odd stack items length

### DIFF
--- a/pickle/pickle.go
+++ b/pickle/pickle.go
@@ -948,8 +948,8 @@ func loadDict(u *Unpickler) error {
 		return err
 	}
 	d := types.NewDict()
-	itemsLen := len(items)
-	for i := 0; i < itemsLen; i += 2 {
+	n := len(items)
+	for i := 0; i < n-1; i += 2 {
 		d.Set(items[i], items[i+1])
 	}
 	u.append(d)

--- a/pickle/pickle_test.go
+++ b/pickle/pickle_test.go
@@ -6,6 +6,7 @@ package pickle
 
 import (
 	"fmt"
+	"io"
 	"math/big"
 	"reflect"
 	"strings"
@@ -751,6 +752,20 @@ func TestP4Carray(t *testing.T) {
 				t.Fatalf("got=%v, want=%v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIssue16(t *testing.T) {
+	var (
+		pkl  = "\x28\x88\x88\x88\x88\x88\x88\x88\x64"
+		want = io.EOF
+	)
+	_, err := Loads(pkl)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if got, want := err.Error(), want.Error(); got != want {
+		t.Fatalf("invalid error:\ngot= %q\nwant=%q", got, want)
 	}
 }
 


### PR DESCRIPTION
loadDict was assuming the items slice popped from the stack was always even. in the odd case where it was odd, an out-of-bound access was issued.

Fixes #16.